### PR TITLE
feat: add config file that links to slack and disallows blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issue_enabled: false,
+blank_issues_enabled: false
 contact_links:
   - name: Unleash community Slack
     url: https://slack.unleash.run

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Unleash community Slack
     url: https://slack.unleash.run

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issue_enabled: false,
+contact_links:
+  - name: Unleash community Slack
+    url: https://slack.unleash.run
+    about: Ask questions and come hang out with the maintainers and the community.


### PR DESCRIPTION
We should discuss whether we want to allow or disallow using blank issues. I think it would be wise to allow it, but I'm happy to hear other points of view.