### PR TITLE
feat: add stalebot config from unleash repo

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+limitPerRun: 30
+daysUntilStale: 30
+daysUntilClose: 7
+
+exemptLabels:
+  - pinned
+  - security
+  - "[Status] Maybe Later"
+
+exemptAssignees: true
+
+staleLabel: wontfix
+
+pulls:
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.
+issues:
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for your contributions.


### PR DESCRIPTION
This PR adds a shareable configuration for the probot-stale bot that we use to monitor for stale issues. It should be usable by other repositories. Repos that use it should put the following in their respective ".github/stale.yml":

```yaml
_extends: .github
```

This solution is based on [this issue comment from the probot-stale repo](https://github.com/probot/stale/issues/220#issuecomment-538467079).