### PR TITLE
meta: Update stalebot config.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,6 +1,6 @@
 limitPerRun: 30
 daysUntilStale: 30
-daysUntilClose: 7
+daysUntilClose: 10
 
 exemptLabels:
   - pinned

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -9,7 +9,7 @@ exemptLabels:
 
 exemptAssignees: true
 
-staleLabel: wontfix
+staleLabel: stale
 
 pulls:
   markComment: >


### PR DESCRIPTION
This PR updates the stalebot config that we're using with an increased "daysUntilStale" and a different stale label.

The changes are:
- `daysUntilStale` is now 10 instead of 7
- `staleLabel` is now `stale` instead of `wontfix`

The **reason** behind these changes are:
- More days until stale: to give the users or maintainer a *little* extra time before something is closed. I've personally felt that things have been closed a bit too fast.
- The label change: when an issue is marked by the stale bot, it doesn't actually mean that we _won't fix it_, it just means that _this issue is stale for now_. I think changing the label to reflect that is preferable.