### PR TITLE
meta: Add roadmap item suggestion to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,10 @@
 <!-- Does it close an issue? Multiple? -->
 Closes # .
 
+<!-- (For internal contributors): Does it relate to an issue on public roadmap (https://github.com/orgs/Unleash/projects/5)? -->
+
+<!-- Relates to roadmap item:  -->
+
 ### Important files
 <!-- PRs can contain a lot of changes, but not all changes are equally important. Where should a reviewer start looking to get an overview of the changes? Are any files particularly important?  -->
 


### PR DESCRIPTION
This change adds an extra (commented out) section to the PR template
asking for links to an Unleash roadmap issue (as discussed in the daily today).

The intention is to make us (internal team mainly) better at linking to roadmap issues so that progress on these issues becomes more visible.