### PR TITLE
Update add-item-to-project.yml

### DIFF
--- a/.github/workflows/add-item-to-project.yml
+++ b/.github/workflows/add-item-to-project.yml
@@ -11,10 +11,7 @@ on:
 
 jobs:
   add-to-project:
-    name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.1.0
-        with:
-          project-url: https://github.com/orgs/Unleash/projects/8
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+      - name: Print message to console
+        run: echo "::notice Not adding this item to the board. This should now be handled automatically by the board itself. Delete this job if it is still active in october."


### PR DESCRIPTION
This change updates the `add-item-to-project` workflow by replacing the workflow content with a notification printed to stdout. 

As of recent, this feature is now supported directly by a project board, so the manual addition isn't required anymore.

More info about github's feature can be found here: https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/adding-items-automatically
