### PR TITLE
chore: use unleash bot for npm releases

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -20,9 +20,6 @@ on:
         type: string
         default: "yarn install --frozen-lockfile"
     secrets:
-      GH_ACCESS_TOKEN:
-        description: "GitHub token with repository write access"
-        required: true
       NPM_ACCESS_TOKEN:
         description: "NPM token allowed to push to the registry"
         required: true
@@ -31,9 +28,16 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.UNLEASH_BOT_APP_ID }}
+          private-key: ${{ secrets.UNLEASH_BOT_TOKEN }}
+
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Setup git config
         run: |
@@ -88,7 +92,7 @@ jobs:
           curl -L --fail-with-body \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GH_ACCESS_TOKEN }}" \
+            -H "Authorization: Bearer ${{ steps.generate-token.outputs.token }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/$GITHUB_REPOSITORY/releases" \
             -d "$WORKFLOW_RELEASE_BODY"

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ secrets.UNLEASH_BOT_APP_ID }}
-          private-key: ${{ secrets.UNLEASH_BOT_TOKEN }}
+          private-key: ${{ secrets.UNLEASH_BOT_PRIVATE_KEY }}
 
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Switch to using the unleash bot for npm releases. Remove redundant GH_ACCESS_TOKEN parameter.