### PR TITLE
chore: update add item to project to use the unleash bot

### DIFF
--- a/.github/workflows/add-item-to-project.yml
+++ b/.github/workflows/add-item-to-project.yml
@@ -2,6 +2,13 @@ name: Add new item to project board
 
 on:
   workflow_call:
+    secrets:
+      UNLEASH_BOT_APP_ID:
+        description: "The app ID for the Unleash bot"
+        required: true
+      UNLEASH_BOT_PRIVATE_KEY:
+        description: "The private key for the Unleash bot"
+        required: true
   issues:
     types:
       - opened
@@ -14,7 +21,14 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.UNLEASH_BOT_APP_ID }}
+          private-key: ${{ secrets.UNLEASH_BOT_PRIVATE_KEY }}
+
       - uses: actions/add-to-project@v0.1.0
         with:
           project-url: https://github.com/orgs/Unleash/projects/8
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          github-token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
This PR updates the workflow that adds items to the project board to
use the new Unleash bot instead of my personal token.

I believe that all sub-repos (I've only checked three, but I remember copy-pasting that config file everywhere) 
are configured with the following job definition, which should make this update automatic and smooth:

```yaml
jobs:
  add-to-project:
      uses: unleash/.github/.github/workflows/add-item-to-project.yml@main
      secrets: inherit
```

But interestingly, the previous secret (add to project pat) was never passed along. Maybe that's a feature you get with `secrets: inherit`? Regardless, I don't think being explicit about the required secrets is a bad thing? 🤷🏼 