### PR TITLE
meta: set npm release workflow back to the minimal required config

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -44,7 +44,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          persist-credentials: false
 
       - name: Setup git config
         run: |
@@ -72,11 +71,9 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
 
       - name: 🚢 Push to git
-        uses: ad-m/github-push-action@v0.8.0
-        with:
-          github_token: ${{ steps.generate-token.outputs.token }}
-          branch: ${{ github.ref_name }}
-          tags: true
+        run: |
+          git push origin ${{ github.ref_name }}
+          git push --tags
 
       - name: 📦️ Publish to NPM
         run: npm publish --access public --tag ${{ inputs.tag }}

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
 
       - name: Setup git config
         run: |


### PR DESCRIPTION
This change makes the npm release workflow as simple as possible again, after we discovered githubs rulesets. 


This makes the final set of changes to this workflow as shown in this comparison: 
https://github.com/Unleash/.github/compare/96a0a010bdb1310682dd5cee639c9f5c27516d8d...b84106127bbc8f28a70d4c96a9527fd6c4a2069b

(yeah, I screwed up the commit history in main a bit. sorry)