### PR TITLE
fix: use GH token to get gh cli access

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -87,6 +87,8 @@ jobs:
         shell: bash
         # uses gh cli tool to create release
         # https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#create-a-release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
GH_TOKEN is required to run gh cli