### PR TITLE
chore(ci): Migrate workflow to use pnpm instead of yarn

### DIFF
--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.UNLEASH_BOT_APP_ID }}
           private-key: ${{ secrets.UNLEASH_BOT_PRIVATE_KEY }}
@@ -54,7 +54,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
 
       - name: Install latest npm version to support trusted publishing

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -18,7 +18,7 @@ on:
       setup-command:
         description: "Command to run before publishing"
         type: string
-        default: "yarn install --frozen-lockfile"
+        default: "pnpm install --frozen-lockfile"
     secrets:
       UNLEASH_BOT_APP_ID:
         description: "The app ID for the Unleash bot"
@@ -60,6 +60,9 @@ jobs:
       - name: Install latest npm version to support trusted publishing
         run: npm install -g npm@latest
 
+      - name: Enable pnpm
+        run: corepack enable pnpm
+
       - name: Set version variable
         # prevent double v "vv1.2.3" tags, go to package directory
         run: |
@@ -70,8 +73,8 @@ jobs:
         run: ${{ inputs.setup-command }}
 
       - name: 🔖 Create version
-        # Yarn, because NPM doen't work with git when in a subdirectory
-        run: yarn version --new-version ${PACKAGE_VERSION} --no-commit-hooks
+        # pnpm, because npm doesn't work with git when in a subdirectory
+        run: pnpm version ${PACKAGE_VERSION} --no-commit-hooks
         working-directory: ${{ inputs.working-directory }}
 
       - name: 🚢 Push to git


### PR DESCRIPTION
We're migrating more and more of our tooling to pnpm. This PR updates to use pnpm instead of yarn for the workflow